### PR TITLE
Fix lat-long swap in  Apple Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # RaycastUI Changelog
 
+## [1.0.1] - 2024-07-24
+
+- Fix latitude longitude coordinate swap when calling Apple Maps
+
 ## [Initial Version] - 2024-02-18

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -24,7 +24,7 @@ export async function openInMaps({ coordinates: c, mapType }: MapsQuery) {
   const up = new URL("maps://maps.apple.com/");
   const mt = mapType ? mapTypeMapping[mapType] : undefined;
   if (c) {
-    up.searchParams.set("ll", `${c.long},${c.lat}`);
+    up.searchParams.set("q", `${c.lat},${c.long}`);
   }
   if (mt) {
     up.searchParams.set("t", mt);

--- a/tests/src/test.tsx
+++ b/tests/src/test.tsx
@@ -52,7 +52,7 @@ export default function MyTest() {
           title="Maps"
           actions={
             <ActionPanel>
-              <Action.OpenMaps title="Coordinates" coordinates={{ long: 51.5007292, lat: -0.1272003 }} />
+              <Action.OpenMaps title="Coordinates" coordinates={{ lat: 51.5007292, long: -0.1272003 }} />
               <Action.OpenMaps title="Map Type" mapType="Satellite" />
             </ActionPanel>
           }


### PR DESCRIPTION
Fix latitude longitude coordinate swap when calling Apple Maps